### PR TITLE
Added square brackets for list in call to np.array

### DIFF
--- a/manim_tutorial_1.py
+++ b/manim_tutorial_1.py
@@ -5,8 +5,8 @@ class Shapes(Scene):
     def construct(self):
         circle = Circle()
         square = Square()
-        line=Line(np.array(3,0,0),np.array(5,0,0))
-        triangle=Polygon(np.array(0,0,0),np.array(1,1,0),np.array(1,-1,0))
+        line=Line(np.array([3,0,0]),np.array([5,0,0]))
+        triangle=Polygon(np.array([0,0,0]),np.array([1,1,0]),np.array([1,-1,0]))
 
         self.add(line)
         self.play(ShowCreation(circle))


### PR DESCRIPTION
Missing brackets produced the error:

`    line=Line(np.array(3,0,0),np.array(5,0,0))
ValueError: only 2 non-keyword arguments accept`
